### PR TITLE
add maps of telco basics

### DIFF
--- a/telecoms/basic_focus/core.map
+++ b/telecoms/basic_focus/core.map
@@ -1,0 +1,56 @@
+title Telecom Core Business
+
+
+component User [0.96, 0.64]
+
+
+component Communicate [0.87, 0.67]
+
+User -> Communicate
+note Content Communication ... [0.86, 0.68]
+
+component Last Mile [0.69, 0.69]
+component Transport [0.69, 0.60]
+component Peering [0.65, 0.53]
+
+Communicate -> Peering
+Communicate -> Last Mile
+Communicate -> Transport
+
+User -> Last Mile
+
+note Who pays Who? [0.65, 0.44]
+note EU no-cost roaming [0.63, 0.29]
+
+
+component Topology [0.54, 0.60]
+pipeline Topology  [0.5,  0.9  ]
+
+Last Mile -> Topology
+Transport -> Topology
+
+component Devices [0.47, 0.65]
+pipeline Devices  [0.5,  0.9 ]
+
+Topology -> Devices
+
+
+component standards [0.41, 0.75]
+Peering -> standards
+
+component Access to commons [0.46, 0.41]
+Topology -> Access to commons
+
+note Radio spectrum, right to dig [0.46, 0.26] label [0.46, 0.26]
+
+component Operational Model [0.37, 0.65] label [1, -39]
+pipeline Operational Model [0.5, 0.9]
+
+Topology -> Operational Model
+
+component Manual Operations [0.35, 0.85] label [-39, 18]
+component Automated Operations [0.35, 0.53] label [-39, 18]
+note Automated Operations are the more evolved form, but less understood at them moment [0.28, 0.53]
+
+Devices -> standards
+

--- a/telecoms/basic_focus/metadata.map
+++ b/telecoms/basic_focus/metadata.map
@@ -1,0 +1,64 @@
+title Telecom Core Business opportunistic banking on meta data
+
+component User [0.96, 0.64]
+
+
+component Communicate [0.87, 0.67]
+
+User -> Communicate
+note Content Communication ... [0.86, 0.68]
+
+component Last Mile [0.69, 0.69]
+component Transport [0.69, 0.60]
+component Peering [0.65, 0.53]
+
+Communicate -> Peering
+Communicate -> Last Mile
+Communicate -> Transport
+
+User -> Last Mile
+
+
+component Topology [0.54, 0.60]
+pipeline Topology  [0.5,  0.9  ]
+
+Last Mile -> Topology
+Transport -> Topology
+
+component Access to commons [0.46, 0.41]
+Topology -> Access to commons
+
+
+
+component telco [0.98, 0.46]
+component government [0.97, 0.54]
+
+
+component commications meta data [0.74, 0.44] label [-100, -39]
+
+commications meta data -> Transport
+commications meta data -> Last Mile
+
+component accountabilty [0.86, 0.38] label [-94, 5]
+
+government -> accountabilty
+accountabilty -> commications meta data
+
+
+component Marketable data [0.87, 0.50]
+telco -> Marketable data
+Marketable data -> commications meta data
+
+
+component privacy [0.91, 0.56]
+
+government -> privacy
+
+
+component Law [0.36, 0.52]
+
+privacy -> Law
+
+Marketable data -> Law // Can't sell it if it is illegal
+
+Access to commons -> Law

--- a/telecoms/basic_focus/services.map
+++ b/telecoms/basic_focus/services.map
@@ -1,0 +1,36 @@
+title Telecom Core Business opportunistic banking on owning the pipe
+
+
+component User [0.96, 0.64]
+
+
+component Communicate [0.87, 0.67]
+
+User -> Communicate
+note Content Communication ... [0.86, 0.68]
+
+component Last Mile [0.69, 0.69]
+component Transport [0.69, 0.60]
+component Peering [0.65, 0.53]
+
+Communicate -> Peering
+Communicate -> Last Mile
+Communicate -> Transport
+
+User -> Last Mile
+
+
+component telco [0.98, 0.46]
+component VAR service provider [0.85, 0.35] label [-76, -16]
+component Market segmentation [0.77, 0.44]
+
+
+telco -> VAR service provider
+telco -> Market segmentation
+
+VAR service provider -> Market segmentation
+
+Market segmentation -> Last Mile
+
+note lots of things below VAR service provider that are not on the map [0.20, 0.03]
+note but I expect the telco are banking on owning the pipeline customer proximity [0.17, 0.03]


### PR DESCRIPTION
I added three maps:

- [https://onlinewardleymaps.com/#qk3Ko7sp4s0KpBeKGy](core.map) mapping the very basics of telco business (providing access to stuff)
- [https://onlinewardleymaps.com/#5d9t67I6Dz01Wa8L0V](services.map) mapping how telcos can opportunistically use their control over the access to provide value added  services and do market segementation (anti-net-neutrality)
- [https://onlinewardleymaps.com/#7JQX5UlAHkFZyuxNQ9](metadata.map) mapping how telcos access to communication meta data brings them into conflict with government